### PR TITLE
WIP: Support for encoding to model levels.

### DIFF
--- a/get_era5_cds.py
+++ b/get_era5_cds.py
@@ -214,6 +214,9 @@ elif levtype=='ml':
     cfglevs = list(range(levstart,138,step))
     # need to be written from bottom level (137) to top for era52arl.cfg
     cfglevs = cfglevs[::-1]
+    # Can only handle 99 levels in ARL files and in HYSPLIT
+    # Since surface level takes up one of those slots, only have 98 available?
+    cfglevs = cfglevs[:98]
 else:
     levs = []
 ##########################################################################################
@@ -235,9 +238,6 @@ else:
    f2d = options.dir + options.fname  + '.2d'
    ftppt = options.dir + options.fname  + '.2df'
    
-if levtype == 'ml':
-   f3d += '.ml'
- 
 file3d = options.dir + f3d
 file2d = options.dir + f2d
 filetppt = options.dir + ftppt
@@ -423,7 +423,7 @@ for wtime in wtimelist:
                     'time'     :  wtime,
                     'step'     : '0',
                     },
-                     'out.grib')
+                     file3d + estr + tstr)
 
             #server.retrieve('reanalysis-era5-complete', {
             #    'class': 'ea',


### PR DESCRIPTION
An attempt at converting ERA5 model-level data to ARL format.

Builds on the model-level code that was already in the hysplit_metdata project.  The Fortran code is modified to extract the hybrid coefficients from the GRIB file and encode them in the level values.

Due to limitations in the ARL format and HYSPLIT code, only 98 levels can be converted.  For now I just chose the lowest 98 ECMWF levels out of the possible 137.

Not sure if everything is entirely correct in the encoding.  Some short tests were run with HYSPLIT, and at least qualitatively the results are similar to the pressure-level version.